### PR TITLE
Remove version range for org.clojure/clojure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
 (defproject net.cgrand/regex "1.1.0"
   :description "a DSL for people who prefer verbose, composable regexes"
   :url "http://github.com/cgrand/regex/"
-  :dependencies [[org.clojure/clojure "[1.2.0,)"]])
+  :dependencies [[org.clojure/clojure "1.2.0"]])


### PR DESCRIPTION
Version ranges are strongly discouraged. They can have various undesirable effects (https://github.com/technomancy/leiningen/wiki/Repeatability#version-ranges) and now produce warnings when running a lein build.
